### PR TITLE
Feature/timeouts and handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When the value of a field remains the same for the specified number of milliseco
 
 ## Usage
 
-If you wanted to enable the delayedChange event for all textareas on the page, you could use this.
+If you wanted to enable the `delayedchange` event for all textareas on the page, you could use this.
 
 ```js
 $('textarea').delayedChange();
@@ -41,6 +41,28 @@ If you wanted to also run some code when the event fired, you could do so like s
 $('textarea').delayedChange().on('delayedchange', function () {
 	// your code here
 	console.log("I'm attached to the 'delayedchange' event for this element.");
+});
+```
+
+You can also specify a [namespace](http://api.jquery.com/on/#event-names) for the event:
+```js
+$('#my-input').delayedChange({
+	eventNamespace: "exciting"
+}).on('delayedchange.exciting', function() {
+	// your code here
+	console.log("I'm attached to the 'delayedchange' event in the 'exciting' namespace.");
+});
+```
+
+The `delayedchange` event passes an extra argument to handlers - an object containing the `delay`, `eventNamespace`, and `extra` attributes set when the plugin was invoked.
+```js
+$('#my-input').delayedChange({
+	delay: 1000,	
+	eventNamespace: "presence",
+	extra: "kilroy was here"
+}).on('delayedchange', function(event, data) {
+	// your code here
+	console.log("got extra data", data.extra); // "kilroy was here"
 });
 ```
 

--- a/jquery.delayedchange.js
+++ b/jquery.delayedchange.js
@@ -22,13 +22,13 @@
 			'delay': 2000, // in milliseconds
 		}, options);
 		this.each(function () {
-			var $this = $(this);
+			var timeoutRef, $this = $(this);
 			// populate initial values
 			if (typeof $this.data('delayedchange-val') == 'undefined') {
 				$this.data('delayedchange-val', $this.val());
 			}
 			$this.on('input propertychange', function () {
-				var val, callback;
+				var val;
 				// handle IE, props: http://stackoverflow.com/questions/5917344/jquery-value-change-event-delay
 				if (window.event && event.type == "propertychange" && event.propertyName != "value") {
 					return;
@@ -39,9 +39,13 @@
 					return;
 				}
 				$this.data('delayedchange-val', val);
-				callback = setTimeout(function () {
+				if (timeoutRef) {
+					clearTimeout(timeoutRef);					
+				}
+				timeoutRef = setTimeout(function () {
 					// only trigger if value has stablized
 					if ($this.val() == val) {
+						timeoutRef = undefined;
 						$this.trigger('delayedchange');
 					}
 				}, settings.delay);

--- a/jquery.delayedchange.js
+++ b/jquery.delayedchange.js
@@ -19,14 +19,13 @@
 (function ($) {
 	$.fn.delayedChange = function (options) {
 		var settings = $.extend({
-			'delay': 2000 // in milliseconds
+			'delay': 2000, // in milliseconds
+			'eventNamespace': undefined
 		}, options);
 		this.each(function () {
-			var timeoutRef, $this = $(this);
+			var timeoutRef, previousValue, $this = $(this);
 			// populate initial values
-			if (typeof $this.data('delayedchange-val') == 'undefined') {
-				$this.data('delayedchange-val', $this.val());
-			}
+			previousValue = $this.val();
 			$this.on('input propertychange', function () {
 				var val;
 				// handle IE, props: http://stackoverflow.com/questions/5917344/jquery-value-change-event-delay
@@ -35,18 +34,22 @@
 				}
 				val = $this.val();
 				// if hasn't changed, do nothing
-				if ($this.data('delayedchange-val') == val) {
+				if (previousValue == val) {
 					return;
 				}
-				$this.data('delayedchange-val', val);
+				previousValue = val;
 				if (timeoutRef) {
 					clearTimeout(timeoutRef);					
 				}
 				timeoutRef = setTimeout(function () {
 					// only trigger if value has stablized
+					var eventName = 'delayedchange';
 					if ($this.val() == val) {
 						timeoutRef = undefined;
-						$this.trigger('delayedchange');
+						if (settings.eventNamespace) {
+							eventName = eventName + '.' + settings.eventNamespace;
+						}
+						$this.trigger(eventName);
 					}
 				}, settings.delay);
 			});

--- a/jquery.delayedchange.js
+++ b/jquery.delayedchange.js
@@ -19,8 +19,9 @@
 (function ($) {
 	$.fn.delayedChange = function (options) {
 		var settings = $.extend({
-			'delay': 2000, // in milliseconds
-			'eventNamespace': undefined
+			delay: 2000, // in milliseconds
+			eventNamespace: undefined,
+			extra: undefined
 		}, options);
 		this.each(function () {
 			var timeoutRef, previousValue, $this = $(this);
@@ -49,7 +50,11 @@
 						if (settings.eventNamespace) {
 							eventName = eventName + '.' + settings.eventNamespace;
 						}
-						$this.trigger(eventName);
+						$this.trigger(eventName, [{
+							delay: settings.delay,
+							eventNamespace: settings.eventNamespace,
+							extra: settings.extra
+						}]);
 					}
 				}, settings.delay);
 			});

--- a/jquery.delayedchange.js
+++ b/jquery.delayedchange.js
@@ -19,7 +19,7 @@
 (function ($) {
 	$.fn.delayedChange = function (options) {
 		var settings = $.extend({
-			'delay': 2000, // in milliseconds
+			'delay': 2000 // in milliseconds
 		}, options);
 		this.each(function () {
 			var timeoutRef, $this = $(this);


### PR DESCRIPTION
- Remove the previous timeout when no longer useful
- Allow more than one delayedChange to be usefully registered against a given element by switching to a closure var rather than .data
- Allow passing a namespace via the settings object
- Allow passing extra data (which is then passed on through the triggered event) via the settings object
